### PR TITLE
#108 fix seeds Sintomas Iniciais

### DIFF
--- a/database/seeds/SintomasSeeder.php
+++ b/database/seeds/SintomasSeeder.php
@@ -13,22 +13,28 @@ class SintomasSeeder extends Seeder
     public function run()
     {
         DB::table('sintomas')->insert(['id' => 1,'nome' => 'Coriza']);
-        DB::table('sintomas')->insert(['id' => 2,'nome' => 'Tosse (seca ou produtiva)']);
-        DB::table('sintomas')->insert(['id' => 3,'nome' => 'Calafrios']);
-        DB::table('sintomas')->insert(['id' => 4,'nome' => 'Febre']);
-        DB::table('sintomas')->insert(['id' => 5,'nome' => 'Dispneia']);
-        DB::table('sintomas')->insert(['id' => 6,'nome' => 'Fadiga']);
-        DB::table('sintomas')->insert(['id' => 7,'nome' => 'Anorexia']);
-        DB::table('sintomas')->insert(['id' => 8,'nome' => 'Mialgia']);
-        DB::table('sintomas')->insert(['id' => 9,'nome' => 'Astenia']);
-        DB::table('sintomas')->insert(['id' => 10,'nome' => 'Dor de Garganta']);
-        DB::table('sintomas')->insert(['id' => 11,'nome' => 'Congestão Nasal']);
-        DB::table('sintomas')->insert(['id' => 12,'nome' => 'Cefaléia']);
-        DB::table('sintomas')->insert(['id' => 13,'nome' => 'Diarréia']);
+        DB::table('sintomas')->insert(['id' => 2,'nome' => 'Congestão Nasal']);
+        DB::table('sintomas')->insert(['id' => 3,'nome' => 'Tosse (seca ou produtiva)']);
+        DB::table('sintomas')->insert(['id' => 4,'nome' => 'Calafrios']);
+        DB::table('sintomas')->insert(['id' => 5,'nome' => 'Febre']);
+        DB::table('sintomas')->insert(['id' => 6,'nome' => 'Dispneia (falta de ar / dificuldade para respirar)']);
+        DB::table('sintomas')->insert(['id' => 7,'nome' => 'Fadiga']);
+        DB::table('sintomas')->insert(['id' => 8,'nome' => 'Hiporexia / Anorexia (diminuição ou perda do apetite)']);
+        DB::table('sintomas')->insert(['id' => 9,'nome' => 'Mialgia (dor muscular)']);
+        DB::table('sintomas')->insert(['id' => 10,'nome' => 'Astenia (cansaço)']);
+        DB::table('sintomas')->insert(['id' => 11,'nome' => 'Odinofagia (dor de garganta)']);
+        DB::table('sintomas')->insert(['id' => 12,'nome' => 'Cefaleia']);
+        DB::table('sintomas')->insert(['id' => 13,'nome' => 'Diarreia']);
         DB::table('sintomas')->insert(['id' => 14,'nome' => 'Náusea']);
         DB::table('sintomas')->insert(['id' => 15,'nome' => 'Vômitos']);
-        DB::table('sintomas')->insert(['id' => 16,'nome' => 'Anosmia']);
-        DB::table('sintomas')->insert(['id' => 17,'nome' => 'Ageusia']);
-        DB::table('sintomas')->insert(['id' => 18,'nome' => 'Síndrome Gripal']);
+        DB::table('sintomas')->insert(['id' => 16,'nome' => 'Mal estar']);
+        DB::table('sintomas')->insert(['id' => 17,'nome' => 'Hiposmia / Anosmia (alteração ou perda do olfato)']);
+        DB::table('sintomas')->insert(['id' => 18,'nome' => 'Disgeusia / Ageusia (alteração ou perda do paladar)']);
+        DB::table('sintomas')->insert(['id' => 19,'nome' => 'Adinamia']);
+        DB::table('sintomas')->insert(['id' => 20,'nome' => 'Síndrome gripal']);
+        DB::table('sintomas')->insert(['id' => 21,'nome' => 'Dor abdominal']);
+        DB::table('sintomas')->insert(['id' => 22,'nome' => 'Dor torácica']);
+        DB::table('sintomas')->insert(['id' => 23,'nome' => 'Artralgia (dor articular)']);
+        DB::table('sintomas')->insert(['id' => 24,'nome' => 'Outros']);
     }
 }

--- a/tests/Feature/Paciente/AtualizacaoDePacienteTest.php
+++ b/tests/Feature/Paciente/AtualizacaoDePacienteTest.php
@@ -60,7 +60,7 @@ class AtualizacaoDePacienteTest extends TestCase
 
         $response->assertJsonFragment([
           'id' => 2,
-          'nome' => 'Tosse (seca ou produtiva)'
+          'nome' => 'Congestão Nasal'
         ]);
     }
 

--- a/tests/Feature/Paciente/MostrarPacienteTest.php
+++ b/tests/Feature/Paciente/MostrarPacienteTest.php
@@ -32,7 +32,7 @@ class MostrarPacienteTest extends TestCase
       
         $response->assertJsonFragment([
         'id' => 2,
-        'nome' => 'Tosse (seca ou produtiva)'
+        'nome' => 'Congestão Nasal'
       ]);
     }
 }

--- a/tests/Feature/Sintomas/ListaDeSintomasCadastradosTest.php
+++ b/tests/Feature/Sintomas/ListaDeSintomasCadastradosTest.php
@@ -30,7 +30,7 @@ class ListaDeSintomasCadastradosTest extends TestCase
     {
         $response = $this->json('GET', 'api/sintomas');
         $response->assertOk();
-        $response->assertJsonCount(18);
+        $response->assertJsonCount(24);
         $response->assertJsonFragment([
             'id' => 1,
             'nome' => 'Coriza'


### PR DESCRIPTION
Na Categoria de Sintomas Iniciais COVID-19
- Ajustar o seeds sintomas:
  - Ajustar os nomes dos campos - devem ficar EXATAMENTE como aparecem no seeds do modelo de dados
  - Incluir Mal estar, Adinamia, Dor abdominal, Dor torácica, Artralgia (dor articular) e Outros
  - Os ajustes devem refletir no front

Obs.: os seeds já foram atualizados