### PR TITLE
Fix Suporte Respiratório response

### DIFF
--- a/app/Http/Controllers/Api/Paciente/SuporteRespiratorio/SuporteRespiratorioController.php
+++ b/app/Http/Controllers/Api/Paciente/SuporteRespiratorio/SuporteRespiratorioController.php
@@ -52,7 +52,7 @@ class SuporteRespiratorioController extends Controller
      *                                  "data_inclusao_desmame": "2020-09-02"
      *                              }
      *                          },
-     *                          "tratamento_suporte": {
+     *                          "suporte_respiratorio": {
      *                              {
      *                                  "id": 22,
      *                                  "tipo_suporte_id": 1,
@@ -78,9 +78,9 @@ class SuporteRespiratorioController extends Controller
 
         $tratamentoPronacao = Pronacao::where('paciente_id', $pacienteId)->get()->toArray();
         $tratamentoInclusaoDesmame = InclusaoDesmame::where('paciente_id', $pacienteId)->get()->toArray();
-        $tratamentoSuporte = SuporteRespiratorio::where('paciente_id', $pacienteId)->get()->toArray();
+        $suporteRespiratorio = SuporteRespiratorio::where('paciente_id', $pacienteId)->get()->toArray();
 
-        if (!count($tratamentoPronacao) && !count($tratamentoInclusaoDesmame) && !count($tratamentoSuporte)) {
+        if (!count($tratamentoPronacao) && !count($tratamentoInclusaoDesmame) && !count($suporteRespiratorio)) {
             return response()->json(
                 [
                     'message' => 'Paciente não possui suportes respiratorios cadastradas',
@@ -90,12 +90,12 @@ class SuporteRespiratorioController extends Controller
             );
         }
 
-        $resultado->push($tratamentoPronacao, $tratamentoInclusaoDesmame, $tratamentoSuporte);
+        $resultado->push($tratamentoPronacao, $tratamentoInclusaoDesmame, $suporteRespiratorio);
 
         return response()->json([
             'tratamento_pronacao' => $tratamentoPronacao,
             'tratamento_inclusao_desmame' => $tratamentoInclusaoDesmame,
-            'tratamento_suporte' => $tratamentoSuporte,
+            'suporte_respiratorio' => $suporteRespiratorio,
         ]);
     }
 

--- a/tests/Feature/Paciente/SuporteRespiratorio/VisualizaSuporteRespiratorioTest.php
+++ b/tests/Feature/Paciente/SuporteRespiratorio/VisualizaSuporteRespiratorioTest.php
@@ -59,7 +59,7 @@ class VisualizaSuporteRespiratorioTest extends TestCase
             'tratamento_inclusao_desmame'
         ]);
         $response->assertJsonStructure([
-            'tratamento_suporte' => []
+            'suporte_respiratorio' => []
         ]);
     }
 }


### PR DESCRIPTION
Renomear retorno da rota Suportes Respiratórios: de "Tratamento_suporte" por "Suporte_respiratório".
![Captura de Tela 2020-09-30 às 14 50 24](https://user-images.githubusercontent.com/67756997/94721692-9fd65400-032c-11eb-9a7a-2beb66634c3f.png)
