### PR TITLE
Feature/167 categoria terapia transfusional

### DIFF
--- a/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
+++ b/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
@@ -129,14 +129,14 @@ class ComplicacoesVentilacaoMecController extends Controller
      */
     public function store(ComplicacaoVentilacaoMecanicaRequest $request, $pacienteId)
     {
-            $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
-                $request->all(),
-                [
+        $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
+            $request->all(),
+            [
                 'paciente_id' => $pacienteId
             ]
-            ));
+        ));
 
-            return response()->json([
+        return response()->json([
             "message" => "Complicação ventilação mecânica cadastrado com sucesso",
             "ventilacao_mecanica" => $complicacaoVentilacaoMec->toArray(),
         ], 201);

--- a/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
+++ b/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\Paciente\ComplicacoesVentilacaoMec;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ComplicacaoVentilacaoMecanicaRequest;
 use App\Models\ComplicacaoVentilacaoMec;
-use App\Models\TransfusaoOcorrencia;
 
 class ComplicacoesVentilacaoMecController extends Controller
 {
@@ -42,17 +41,9 @@ class ComplicacoesVentilacaoMecController extends Controller
      *                                  "data_complicacao": "2020-08-19",
      *                                  "descricao": "descricao qualquer",
      *                                  "tipo_complicacao": {
-     *                                       "id": 4,
-     *                                       "descricao": "Necessidade transfusional"
+     *                                       "id": 1,
+     *                                       "descricao": "Pneumotórax"
      *                                   }
-     *                              }
-     *                          },
-     *                          "transfussoes_ocorrencia": {
-     *                              {
-     *                                  "id": 1,
-     *                                  "data_transfusao": "2020-08-19",
-     *                                  "volume_transfusao": "4.2",
-     *                                  "tipos_transfussoes": null
      *                              }
      *                          }
      *                      }
@@ -68,9 +59,8 @@ class ComplicacoesVentilacaoMecController extends Controller
     public function index($pacienteId)
     {
         $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::where('paciente_id', $pacienteId)->get()->toArray();
-        $transfusaoOcorrencia = TransfusaoOcorrencia::where('paciente_id', $pacienteId)->get()->toArray();
 
-        if (!count($complicacaoVentilacaoMec) && !count($transfusaoOcorrencia)) {
+        if (!count($complicacaoVentilacaoMec)) {
             return response()->json(
                 [
                     'message' => 'Paciente não possui complicações cadastradas',
@@ -82,8 +72,7 @@ class ComplicacoesVentilacaoMecController extends Controller
         }
 
         return response()->json([
-            'complicacoes_ventilacao_mecanica' => $complicacaoVentilacaoMec,
-            'transfussoes_ocorrencia' => $transfusaoOcorrencia
+            'complicacoes_ventilacao_mecanica' => $complicacaoVentilacaoMec
         ]);
     }
 
@@ -107,15 +96,13 @@ class ComplicacoesVentilacaoMecController extends Controller
      *          )
      *      ),
      *      @OA\RequestBody(
-     *          description="Os campos a seguir não são obrigatórios mas se data_complicacao for preenchido obrigatoriamente tipo_complicacao_id é obrigatorio e vice-versa. O mesmo acontece com data_transfusao e tipo_transfusao_id.",
-     *          required=false,
+     *          description="Os campos a seguir não são obrigatórios para inserção.",
+     *          required=true,
      *          @OA\JsonContent(
+     *              required={"tipo_complicacao_id","data_complicacao"}
      *              @OA\Property(property="tipo_complicacao_id", type="integer", example=4),
      *              @OA\Property(property="data_complicacao", type="string", example="2020-08-19"),
-     *              @OA\Property(property="descricao", type="string", example="descricao da complicacao"),
-     *              @OA\Property(property="tipo_transfusao_id", type="integer", example=1),
-     *              @OA\Property(property="data_transfusao", type="string", example="2020-08-20"),
-     *              @OA\Property(property="volume_transfusao", type="float", example=4.2)
+     *              @OA\Property(property="descricao", type="string", example="descricao da complicacao")
      *          )
      *      ),
      *      @OA\Response(
@@ -131,11 +118,6 @@ class ComplicacoesVentilacaoMecController extends Controller
      *                              "data_complicacao": "2020-08-19",
      *                              "descricao": "descricao da complicacao",
      *                              "id": 2
-     *                          },
-     *                          "transfusao_ocorrencia": {
-     *                              "data_transfusao": "2020-08-25",
-     *                              "volume_transfusao": 4.2,
-     *                              "id": 3
      *                          }
      *                      }
      *                  )
@@ -147,37 +129,16 @@ class ComplicacoesVentilacaoMecController extends Controller
      */
     public function store(ComplicacaoVentilacaoMecanicaRequest $request, $pacienteId)
     {
-        if ($request->has(['tipo_complicacao_id', 'data_complicacao'])) {
-            $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
-                $request->only(['tipo_complicacao_id', 'data_complicacao', 'descricao']),
-                [
-                    'paciente_id' => $pacienteId
-                ]
-            ));
-
-            if ($request->input('tipo_complicacao_id') == 4) {
-                $transfusaoOcorrencia = new TransfusaoOcorrencia();
-                $transfusaoOcorrencia->tipo_transfusao_id = $request->tipo_transfusao_id;
-                $transfusaoOcorrencia->data_transfusao = $request->data_complicacao;
-                $transfusaoOcorrencia->volume_transfusao = $request->volume_transfusao;
-                $transfusaoOcorrencia->paciente_id = $pacienteId;
-                $transfusaoOcorrencia->save();
-            }
-        }
-
-        if ($request->has(['tipo_transfusao_id', 'data_transfusao', 'volume_transfusao'])) {
-            $transfusaoOcorrencia = TransfusaoOcorrencia::create(array_merge(
-                $request->only(['tipo_transfusao_id', 'data_transfusao', 'volume_transfusao']),
-                [
-                    'paciente_id' => $pacienteId
-                ]
-            ));
-        }
+        $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
+            $request->json(),
+            [
+                'paciente_id' => $pacienteId
+            ]
+        ));
 
         return response()->json([
             "message" => "Complicação ventilação mecânica cadastrado com sucesso",
-            "ventilacao_mecanica" => isset($complicacaoVentilacaoMec) ? $complicacaoVentilacaoMec->toArray() : [],
-            "transfusao_ocorrencia" => isset($transfusaoOcorrencia) ? $transfusaoOcorrencia->toArray() : []
+            "ventilacao_mecanica" => $complicacaoVentilacaoMec->toArray(),
         ], 201);
     }
 }

--- a/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
+++ b/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Paciente\ComplicacoesVentilacaoMec;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ComplicacaoVentilacaoMecanicaRequest;
 use App\Models\ComplicacaoVentilacaoMec;
+use Exception;
 
 class ComplicacoesVentilacaoMecController extends Controller
 {
@@ -129,8 +130,9 @@ class ComplicacoesVentilacaoMecController extends Controller
      */
     public function store(ComplicacaoVentilacaoMecanicaRequest $request, $pacienteId)
     {
+        try{
         $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
-            $request->json(),
+            $request->all(),
             [
                 'paciente_id' => $pacienteId
             ]
@@ -140,5 +142,8 @@ class ComplicacoesVentilacaoMecController extends Controller
             "message" => "Complicação ventilação mecânica cadastrado com sucesso",
             "ventilacao_mecanica" => $complicacaoVentilacaoMec->toArray(),
         ], 201);
+    } catch (Exception $e){
+        dd($e);
+    }
     }
 }

--- a/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
+++ b/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
@@ -129,7 +129,6 @@ class ComplicacoesVentilacaoMecController extends Controller
      */
     public function store(ComplicacaoVentilacaoMecanicaRequest $request, $pacienteId)
     {
-        try {
             $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
                 $request->all(),
                 [
@@ -141,8 +140,5 @@ class ComplicacoesVentilacaoMecController extends Controller
             "message" => "Complicação ventilação mecânica cadastrado com sucesso",
             "ventilacao_mecanica" => $complicacaoVentilacaoMec->toArray(),
         ], 201);
-        } catch (Exception $e) {
-            dd($e);
-        }
     }
 }

--- a/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
+++ b/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
@@ -129,20 +129,20 @@ class ComplicacoesVentilacaoMecController extends Controller
      */
     public function store(ComplicacaoVentilacaoMecanicaRequest $request, $pacienteId)
     {
-        try{
-        $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
-            $request->all(),
-            [
+        try {
+            $complicacaoVentilacaoMec = ComplicacaoVentilacaoMec::create(array_merge(
+                $request->all(),
+                [
                 'paciente_id' => $pacienteId
             ]
-        ));
+            ));
 
-        return response()->json([
+            return response()->json([
             "message" => "Complicação ventilação mecânica cadastrado com sucesso",
             "ventilacao_mecanica" => $complicacaoVentilacaoMec->toArray(),
         ], 201);
-    } catch (Exception $e){
-        dd($e);
-    }
+        } catch (Exception $e) {
+            dd($e);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
+++ b/app/Http/Controllers/Api/Paciente/ComplicacoesVentilacaoMec/ComplicacoesVentilacaoMecController.php
@@ -65,8 +65,7 @@ class ComplicacoesVentilacaoMecController extends Controller
             return response()->json(
                 [
                     'message' => 'Paciente não possui complicações cadastradas',
-                    'complicacoes_ventilacao_mecanica' => [],
-                    'transfussoes_ocorrencia' => []
+                    'complicacoes_ventilacao_mecanica' => []
                 ],
                 200
             );

--- a/app/Http/Controllers/Api/Paciente/TerapiaTransfusional/TerapiaTransfusionalController.php
+++ b/app/Http/Controllers/Api/Paciente/TerapiaTransfusional/TerapiaTransfusionalController.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace App\Http\Controllers\api;
+namespace App\Http\Controllers\Api\Paciente\TerapiaTransfusional;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\TerapiaTranfusionalRequest;
 use App\Models\TerapiaTransfusional;
 use App\Models\TransfusaoOcorrencia;
+use Exception;
 use Illuminate\Http\Request;
 
 class TerapiaTransfusionalController extends Controller
@@ -128,15 +129,16 @@ class TerapiaTransfusionalController extends Controller
     public function store(TerapiaTranfusionalRequest $request, $pacienteId)
     {
         $transfusaoOcorrencia = TerapiaTransfusional::create(array_merge(
-            $request->post(),
+            $request->all(),
             [
                 'paciente_id' => $pacienteId
             ]
         ));
 
         return response()->json([
-            "message" => "Complicação ventilação mecânica cadastrado com sucesso",
+            "message" => "Terapia Transfusional cadastrada com sucesso",
             "terapia_transfusional" => $transfusaoOcorrencia->toArray()
         ], 201);
+    
     }
 }

--- a/app/Http/Controllers/Api/Paciente/TerapiaTransfusional/TerapiaTransfusionalController.php
+++ b/app/Http/Controllers/Api/Paciente/TerapiaTransfusional/TerapiaTransfusionalController.php
@@ -101,7 +101,7 @@ class TerapiaTransfusionalController extends Controller
      *              @OA\Property(property="tipo_transfusao_id", type="integer", example=1),
      *              @OA\Property(property="data_transfusao", type="string", example="2020-08-20"),
      *              @OA\Property(property="volume_transfusao", type="float", example=4.2),
-     *              
+     *
      *          )
      *      ),
      *      @OA\Response(
@@ -139,6 +139,5 @@ class TerapiaTransfusionalController extends Controller
             "message" => "Terapia Transfusional cadastrada com sucesso",
             "terapia_transfusional" => $transfusaoOcorrencia->toArray()
         ], 201);
-    
     }
 }

--- a/app/Http/Controllers/Api/Paciente/TerapiaTransfusional/TerapiaTransfusionalController.php
+++ b/app/Http/Controllers/Api/Paciente/TerapiaTransfusional/TerapiaTransfusionalController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TerapiaTranfusionalRequest;
+use App\Models\TerapiaTransfusional;
+use App\Models\TransfusaoOcorrencia;
+use Illuminate\Http\Request;
+
+class TerapiaTransfusionalController extends Controller
+{
+    /**
+     * Exibi terapias transfusionais do paciente
+     *
+     * @OA\Get(
+     *      path="/api/pacientes/{pacienteId}/terapia-transfusional",
+     *      operationId="getTerapiasTransfusionais",
+     *      tags={"Paciente"},
+     *      summary="Exibi terapias transfusionais do paciente cadastrada",
+     *      description="Mostra identificação do paciente cadastrada",
+     *      @OA\Parameter(
+     *          name="id",
+     *          description="ID do paciente previamente cadastrado",
+     *          required=true,
+     *          in="path",
+     *          @OA\Schema(
+     *              type="integer"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Executado com sucesso",
+     *          content={
+     *              @OA\MediaType(
+     *                  mediaType="application/json",
+     *                  @OA\Schema(
+     *                      example={
+     *                          "transfussoes_ocorrencia": {
+     *                              {
+     *                                  "id": 1,
+     *                                  "data_transfusao": "2020-08-19",
+     *                                  "volume_transfusao": "4.2",
+     *                                  "tipos_transfussoes": null
+     *                              }
+     *                          }
+     *                      }
+     *                  )
+     *              )
+     *          }
+     *       ),
+     *      @OA\Response(response=401, description="Unauthorized"),
+     * )
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index($pacienteId)
+    {
+        $terapiaTransfusional = TerapiaTransfusional::where('paciente_id', $pacienteId)->get()->toArray();
+
+        if (!count($terapiaTransfusional)) {
+            return response()->json(
+                [
+                    'message' => 'Paciente não possui Terapias Transfusionais cadastradas',
+                    'terapia_transfusional' => []
+                ],
+                200
+            );
+        }
+
+        return response()->json([
+            'transfussoes_ocorrencia' => $terapiaTransfusional
+        ]);
+    }
+
+
+    /**
+     * Cadastra terapias transfusionais do paciente no sistema
+     *
+     * @OA\Post(
+     *      path="/api/pacientes/{pacienteId}/terapia-transfusional",
+     *      operationId="storeTerapiaTransfusional",
+     *      tags={"Paciente"},
+     *      summary="Cadastra de identificação do paciente",
+     *      description="Cadastra de identificação do paciente",
+     *      @OA\Parameter(
+     *          name="id",
+     *          description="ID do paciente previamente cadastrado",
+     *          required=true,
+     *          in="path",
+     *          @OA\Schema(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\RequestBody(
+     *          description="Exemplo de JSON a ser enviado",
+     *          required=true,
+     *          @OA\JsonContent(
+     *              required={"tipo_transfusao_id", "data_transfusao"},
+     *              @OA\Property(property="tipo_transfusao_id", type="integer", example=1),
+     *              @OA\Property(property="data_transfusao", type="string", example="2020-08-20"),
+     *              @OA\Property(property="volume_transfusao", type="float", example=4.2),
+     *              
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Executado com sucesso",
+     *          content={
+     *              @OA\MediaType(
+     *                  mediaType="application/json",
+     *                  @OA\Schema(
+     *                      example={
+     *                          "message": "Terapia Transfusional cadastrado com sucesso",
+     *                          "transfusao_ocorrencia": {
+     *                              "data_transfusao": "2020-08-25",
+     *                              "volume_transfusao": 4.2,
+     *                              "id": 3
+     *                          }
+     *                      }
+     *                  )
+     *              )
+     *          }
+     *       ),
+     *      @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function store(TerapiaTranfusionalRequest $request, $pacienteId)
+    {
+        $transfusaoOcorrencia = TerapiaTransfusional::create(array_merge(
+            $request->post(),
+            [
+                'paciente_id' => $pacienteId
+            ]
+        ));
+
+        return response()->json([
+            "message" => "Complicação ventilação mecânica cadastrado com sucesso",
+            "terapia_transfusional" => $transfusaoOcorrencia->toArray()
+        ], 201);
+    }
+}

--- a/app/Http/Requests/ComplicacaoVentilacaoMecanicaRequest.php
+++ b/app/Http/Requests/ComplicacaoVentilacaoMecanicaRequest.php
@@ -17,8 +17,6 @@ class ComplicacaoVentilacaoMecanicaRequest extends FormRequest
             'tipo_complicacao_id' => 'integer',
             'data_complicacao' => 'required_with:tipo_complicacao_id|date',
             'descricao' => 'nullable|string',
-            'tipo_transfusao_id' => 'integer|exists:tipos_transfusao,id',
-            'volume_transfusao' => 'nullable|regex:/^\d+(\.\d{1,2})?$/'
         ];
     }
 }

--- a/app/Http/Requests/TerapiaTransfusionalRequest.php
+++ b/app/Http/Requests/TerapiaTransfusionalRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TerapiaTranfusionalRequest extends FormRequest
+{
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'data_transfusao' => 'required|date',
+            'tipo_transfusao_id' => 'required|integer|exists:tipos_transfusao,id',
+            'volume_transfusao' => 'nullable|regex:/^\d+(\.\d{1,2})?$/'
+        ];
+    }
+}

--- a/app/Models/Paciente.php
+++ b/app/Models/Paciente.php
@@ -107,11 +107,11 @@ class Paciente extends Model
             foreach ($complicacoesVM as $complicacao) {
                 $complicacao->delete();
             }
-            try{
-            $transfusoes = TerapiaTransfusional::where('paciente_id', $paciente->id)->get();
-            foreach ($transfusoes as $transfusao) {
-                $transfusao->delete();
-            }
+            try {
+                $transfusoes = TerapiaTransfusional::where('paciente_id', $paciente->id)->get();
+                foreach ($transfusoes as $transfusao) {
+                    $transfusao->delete();
+                }
             } catch (Exception $err) {
                 dd($err);
             }

--- a/app/Models/Paciente.php
+++ b/app/Models/Paciente.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -106,10 +107,13 @@ class Paciente extends Model
             foreach ($complicacoesVM as $complicacao) {
                 $complicacao->delete();
             }
-
-            $transfusoes = TransfusaoOcorrencia::where('paciente_id', $paciente->id)->get();
+            try{
+            $transfusoes = TerapiaTransfusional::where('paciente_id', $paciente->id)->get();
             foreach ($transfusoes as $transfusao) {
                 $transfusao->delete();
+            }
+            } catch (Exception $err) {
+                dd($err);
             }
 
             $defechos = Desfecho::where('paciente_id', $paciente->id)->get();

--- a/app/Models/Paciente.php
+++ b/app/Models/Paciente.php
@@ -107,13 +107,9 @@ class Paciente extends Model
             foreach ($complicacoesVM as $complicacao) {
                 $complicacao->delete();
             }
-            try {
-                $transfusoes = TerapiaTransfusional::where('paciente_id', $paciente->id)->get();
-                foreach ($transfusoes as $transfusao) {
-                    $transfusao->delete();
-                }
-            } catch (Exception $err) {
-                dd($err);
+            $transfusoes = TerapiaTransfusional::where('paciente_id', $paciente->id)->get();
+            foreach ($transfusoes as $transfusao) {
+                $transfusao->delete();
             }
 
             $defechos = Desfecho::where('paciente_id', $paciente->id)->get();

--- a/app/Models/TerapiaTransfusional.php
+++ b/app/Models/TerapiaTransfusional.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class TerapiaTransfusional extends Model
 {
+    protected $table = 'transfusao_ocorrencias';
+
     protected $fillable = [
         'paciente_id',
         'tipo_transfusao_id',

--- a/app/Models/TerapiaTransfusional.php
+++ b/app/Models/TerapiaTransfusional.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class TransfusaoOcorrencia extends Model
+class TerapiaTransfusional extends Model
 {
     protected $fillable = [
         'paciente_id',

--- a/database/seeds/TipoComplicacaoVMSeeder.php
+++ b/database/seeds/TipoComplicacaoVMSeeder.php
@@ -29,11 +29,6 @@ class TipoComplicacaoVMSeeder extends Seeder
 
         DB::table('tipos_complicacao_vm')->insert([
             'id'   => 4,
-            'descricao' => 'Necessidade transfusional',
-        ]);
-
-        DB::table('tipos_complicacao_vm')->insert([
-            'id'   => 5,
             'descricao' => 'Outras',
         ]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -62,6 +62,8 @@ Route::group(['middleware' => ['apiJwt']], function ($router) {
                 Route::get('/pacientes/{pacienteId}/tratamento-suporte', 'TratamentoSuporte\TratamentoSuporteController@index');
                 Route::post('pacientes/{pacienteId}/ventilacao-mecanica', 'ComplicacoesVentilacaoMec\ComplicacoesVentilacaoMecController@store');
                 Route::get('pacientes/{pacienteId}/ventilacao-mecanica', 'ComplicacoesVentilacaoMec\ComplicacoesVentilacaoMecController@index');
+                Route::post('pacientes/{pacienteId}/terapia-transfusional', 'TerapiaTransfusional\TerapiaTransfusionalController@store');
+                Route::get('pacientes/{pacienteId}/terapia-transfusional', 'TerapiaTransfusional\TerapiaTransfusionalController@index');
 
                 Route::get('/pacientes/{pacienteId}/evolucoes-diarias/{evolucaoId}', 'EvolucaoDiariaController@show');
 

--- a/tests/Feature/Paciente/ComplicacoesVentilacaoMec/CadastroComplicacaoTest.php
+++ b/tests/Feature/Paciente/ComplicacoesVentilacaoMec/CadastroComplicacaoTest.php
@@ -23,11 +23,9 @@ class CadastroComplicacaoTest extends TestCase
         ]);
 
         $data = [
-            "tipo_complicacao_id" => 4,
+            "tipo_complicacao_id" => 1,
             "data_complicacao" => "2020-08-10",
-            "descricao" => "descricao qualquer",
-            "tipo_transfusao_id" => 5,
-            "volume_transfusao" => 6.2
+            "descricao" => "descricao qualquer"
         ];
 
         $response = $this->postJson("api/pacientes/{$paciente->id}/ventilacao-mecanica", $data);
@@ -38,9 +36,9 @@ class CadastroComplicacaoTest extends TestCase
         $response->assertJsonStructure([
             "ventilacao_mecanica"
         ]);
-        $response->assertJsonStructure([
-            "transfusao_ocorrencia"
-        ]);
+        // $response->assertJsonStructure([
+        //     "transfusao_ocorrencia"
+        // ]);
     }
 
     /**
@@ -73,14 +71,6 @@ class CadastroComplicacaoTest extends TestCase
             [
                 ['descricao' => 0],
                 ['descricao' => ['O campo descricao deve ser uma string.']]
-            ],
-            [
-                ['tipo_transfusao_id' => 0],
-                ['errors' => ['tipo_transfusao_id' => ['O campo tipo transfusao id selecionado é inválido.']]]
-            ],
-            [
-                ['volume_transfusao' => 'teste'],
-                ['errors' => ['volume_transfusao' => ['O campo volume transfusao tem um formato inválido.']]]
             ]
         ];
     }

--- a/tests/Feature/Paciente/TerapiaTransfusional/CadastroTerapiaTransfusionalTest.php
+++ b/tests/Feature/Paciente/TerapiaTransfusional/CadastroTerapiaTransfusionalTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Paciente\TerapiaTransfusional;
+
+use App\Models\Paciente;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class CadastroTerapiaTransfusionalTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->authenticated();
+    }
+
+    public function testCadastroTerapiaTransfusionalComSucesso()
+    {
+        $paciente = factory(Paciente::class)->create([
+            'coletador_id' => $this->currentUser->id
+        ]);
+
+        $data = [
+            "tipo_transfusao_id" => 1,
+            "data_transfusao" => "2020-08-10",
+            "volume_transfusao" => 1
+        ];
+
+        $response = $this->postJson("api/pacientes/{$paciente->id}/terapia-transfusional", $data);
+        $response->assertStatus(201);
+        $response->assertJsonFragment([
+            "message" => "Terapia Transfusional cadastrada com sucesso",
+        ]);
+        $response->assertJsonStructure([
+            "terapia_transfusional"
+        ]);
+    }
+
+    /**
+     * @param $dados
+     * @param $erro
+     * @dataProvider cenariosValidacao
+     */
+    public function testValidaCampos($dados, $erro)
+    {
+        $paciente = factory(Paciente::class)->create([
+            'coletador_id' => $this->currentUser->id
+        ]);
+
+        $response = $this->postJson("api/pacientes/{$paciente->id}/terapia-transfusional", $dados);
+        $response->assertStatus(422);
+        $response->assertJsonFragment($erro);
+        // dd($response->baseResponse->getContent(), $erro);
+        
+    }
+
+    public function cenariosValidacao()
+    {
+        return [
+            [
+                ['data_transfusao' => 0],
+                ['data_transfusao' => ['O campo data transfusao não é uma data válida.']]
+            ],
+            [
+                ['tipo_transfusao_id' => 0],
+                ['tipo_transfusao_id' => ['O campo tipo transfusao id selecionado é inválido.']]
+            ],
+            [
+                ['volume_transfusao' => 'teste'],
+                ['volume_transfusao' => ['O campo volume transfusao tem um formato inválido.']]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
---
Responsáveis: @FelipeSVidal 
Linked Issue: Resolve #167
---

# Descrição

Atualmente o formulário Necessidade Transfusional faz parte da categoria Complicações Relacionadas à ventilação mecânica, indevidamente. Vamos criar uma nova categoria para migração deste formulário.
E deverá ser alterado o nome Necessidade Transfusional para Terapia Transfusional, essa alteração deve ser refletida em todas as partes do sistema em que o nome estiver referenciado.

# Passos a passo para teste

Rotas: 
 get - /api/pacientes/{pacienteId}/terapia-transfusional
 post - /api/pacientes/{pacienteId}/terapia-transfusional, data={
    "tipo_transfusao_id": 2,
    "data_transfusao" : "2020-08-27",
   "volume_transfusao" : 0.1
}